### PR TITLE
Link updates for MacType and bbZero

### DIFF
--- a/index.html
+++ b/index.html
@@ -593,7 +593,7 @@ font-family: 'Open Sans';
 	         <li ><div >Recommended for Windows XP and 7</div></li>
 	         <li ><div ><a href="http://blackbox4windows.com/index.php?/topic/123-mojmirs-build/">BlackboxZero Newest Releases</a> - <a href="https://github.com/xzero450/bbclean-xzero450">Github Repository</a></div></li>  
 	         <li ><div ><a href="http://blackbox4windows.com/index.php?/topic/69-old-builds/">Old Builds</a></div></li>
-	         <li ><div ><a href="http://spoonm.org/share/bbzero/">Latest bbZero build unofficial mirror(no registration required)</a></div></li>
+	         <li ><div ><a href="http://spoonm.org/bbzero/">Latest bbZero build unofficial mirror(no registration required)</a></div></li>
 	         <li ><div >&nbsp;</div></li>
 	         <li ><div >-Plugins-</div></li>
 	         <li ><div ><a href="http://bb4win.sourceforge.net/bblean/docs/bblean_overview.htm#Plugins">How To Load A Plugin</a></div></li>

--- a/index.html
+++ b/index.html
@@ -449,7 +449,6 @@ font-family: 'Open Sans';
 	         <li ><div >Now you can compare programming font rendering live on your webpage with <a href="http://www.s9w.io/font_compare/">this font compare tool</a>! See the difference between cleartype, mactype and gdipp with your own eyes.</div></li>
 	         <li ><div >&nbsp;</div></li>
 			 <li ><div >MacType is now open source and receiving updates! New releases are available at: <a href="https://github.com/snowie2000/mactype">snowie2000s repo</a>.</div></li>
-	         <li ><div >A mirror is still available on spoonms page: <a href="http://spoonm.org/share/mactype.exe">spoonm.org/share/mactype.exe</a></div></li>
 	         <li ><div >Having issues with mactype and direct write? This may help: <a href="https://github.com/silight-jp/MacType-Patch">silight-jp MacType-Patch</a></div></li>
 	         <li ><div >&nbsp;</div></li>
 	         <li ><div >Recommended fixes for Firefox/Nightly:</div></li>

--- a/index.html
+++ b/index.html
@@ -448,7 +448,7 @@ font-family: 'Open Sans';
 	         <li ><div >&nbsp;</div></li>
 	         <li ><div >Now you can compare programming font rendering live on your webpage with <a href="http://www.s9w.io/font_compare/">this font compare tool</a>! See the difference between cleartype, mactype and gdipp with your own eyes.</div></li>
 	         <li ><div >&nbsp;</div></li>
-			 <li ><div >MacType is now open source and receiving updates! New releases are available at: <a href="https://github.com/snowie2000/mactype">snowie2000s repo</a>.</div></li>
+			 <li ><div >MacType is now open source and receiving updates! New releases are available at: <a href="https://github.com/snowie2000/mactype">snowie2000s repo</a>, and on <a href="http://mactype.net/">the project's homepage</a>.</div></li>
 	         <li ><div >Having issues with mactype and direct write? This may help: <a href="https://github.com/silight-jp/MacType-Patch">silight-jp MacType-Patch</a></div></li>
 	         <li ><div >&nbsp;</div></li>
 	         <li ><div >Recommended fixes for Firefox/Nightly:</div></li>


### PR DESCRIPTION
I recently took down my mirror for the old MacType installer, seeing as there have been several releases since, updating it for Windows 10 compatibility and everything. Upon removing the link, I took the liberty of linking to the project homepage as well, even though right now that brings no real benefit over checking snowie2000's repo directly.

The link to the bbZero mirror was also updated.